### PR TITLE
Fix build error on Linux

### DIFF
--- a/ext/string/crypt/crypt.c
+++ b/ext/string/crypt/crypt.c
@@ -1,7 +1,7 @@
-#include <errno.h>
-
 #include "ruby.h"
 #include "ruby/encoding.h"
+
+#include <errno.h>
 
 #if defined HAVE_STRING_CRYPT_R
 # if defined HAVE_STRING_CRYPT_H


### PR DESCRIPTION
`gem install string-crypt` fails on my Ubuntu 18.10.

```
$ rake test
cd tmp/x86_64-linux/string/crypt/2.5.3
/usr/bin/make
compiling ../../../../../ext/string/crypt/crypt.c
In file included from /home/mame/local/include/ruby-2.5.0/ruby.h:33,
                 from ../../../../../ext/string/crypt/crypt.c:3:
../../../../../ext/string/crypt/crypt.c: In function ‘rb_string_crypt’:
../../../../../ext/string/crypt/crypt.c:81:35: error: invalid application of ‘sizeof’ to incomplete type ‘struct crypt_data’
     data = ALLOCV(databuf, sizeof(struct crypt_data));
                                   ^~~~~~
/home/mame/local/include/ruby-2.5.0/ruby/ruby.h:1652:28: note: in definition of macro ‘RB_ALLOCV’
 # define RB_ALLOCV(v, n) ((n) < RUBY_ALLOCV_LIMIT ? \
                            ^
../../../../../ext/string/crypt/crypt.c:81:12: note: in expansion of macro ‘ALLOCV’
     data = ALLOCV(databuf, sizeof(struct crypt_data));
            ^~~~~~
In file included from /usr/include/stdlib.h:566,
                 from /home/mame/local/include/ruby-2.5.0/ruby/defines.h:120,
                 from /home/mame/local/include/ruby-2.5.0/ruby/ruby.h:29,
                 from /home/mame/local/include/ruby-2.5.0/ruby.h:33,
                 from ../../../../../ext/string/crypt/crypt.c:3:
../../../../../ext/string/crypt/crypt.c:81:35: error: invalid application of ‘sizeof’ to incomplete type ‘struct crypt_data’
     data = ALLOCV(databuf, sizeof(struct crypt_data));
                                   ^~~~~~
/home/mame/local/include/ruby-2.5.0/ruby/ruby.h:1662:22: note: in expansion of macro ‘RB_ALLOCV’
 #define ALLOCV(v, n) RB_ALLOCV(v, n)
                      ^~~~~~~~~
../../../../../ext/string/crypt/crypt.c:81:12: note: in expansion of macro ‘ALLOCV’
     data = ALLOCV(databuf, sizeof(struct crypt_data));
            ^~~~~~
In file included from /home/mame/local/include/ruby-2.5.0/ruby.h:33,
                 from ../../../../../ext/string/crypt/crypt.c:3:
../../../../../ext/string/crypt/crypt.c:81:35: error: invalid application of ‘sizeof’ to incomplete type ‘struct crypt_data’
     data = ALLOCV(databuf, sizeof(struct crypt_data));
                                   ^~~~~~
/home/mame/local/include/ruby-2.5.0/ruby/ruby.h:1654:37: note: in definition of macro ‘RB_ALLOCV’
          rb_alloc_tmp_buffer(&(v), (n)))
                                     ^
../../../../../ext/string/crypt/crypt.c:81:12: note: in expansion of macro ‘ALLOCV’
     data = ALLOCV(databuf, sizeof(struct crypt_data));
            ^~~~~~
../../../../../ext/string/crypt/crypt.c:83:9: error: dereferencing pointer to incomplete type ‘struct crypt_data’
     data->initialized = 0;
         ^~
../../../../../ext/string/crypt/crypt.c:85:11: warning: implicit declaration of function ‘crypt_r’; did you mean ‘crypt’? [-Wimplicit-function-declaration]
     res = crypt_r(s, saltp, data);
           ^~~~~~~
           crypt
../../../../../ext/string/crypt/crypt.c:85:9: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
     res = crypt_r(s, saltp, data);
         ^
../../../../../ext/string/crypt/crypt.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
make: *** [Makefile:242: crypt.o] エラー 1
rake aborted!
Command failed with status (2): [/usr/bin/make...]

Tasks: TOP => test => compile => compile:x86_64-linux => compile:string/crypt:x86_64-linux => copy:string/crypt:x86_64-linux:2.5.3 => tmp/x86_64-linux/string/crypt/2.5.3/string/crypt.so
(See full trace by running task with --trace)
```

`#define _GNU_SOURCE` is needed to use `crypt_r`.
I'm unsure why, but rearranging `#include` directives fixes the issue.